### PR TITLE
feat: Theme사용을 위한 ThemeProvider활용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
+import { ThemeProvider } from 'styled-components'
 import Router from './routes/Router'
 import GlobalStyles from './styles/GlobalStyles'
 import { QueryClient, QueryClientProvider } from 'react-query'
+import { theme } from './styles/Theme'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -14,7 +16,9 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <GlobalStyles />
-      <Router />
+      <ThemeProvider theme={theme}>
+        <Router />
+      </ThemeProvider>
     </QueryClientProvider>
   )
 }

--- a/src/styles/GlobalColor.ts
+++ b/src/styles/GlobalColor.ts
@@ -1,0 +1,73 @@
+/**
+ * 활용예시
+ * export const SideBar = styled.div`
+  background-color: ${GlobalColors.blueDisable};
+  `
+ * mainColor: 메인컬러 입니다.
+ *
+ * white: 흰색이 활용되는 폰트,버튼에 활용되는 컬러입니다.
+ *
+ * black: 검은색이 활용되는 폰트,버튼에 활용되는 컬러입니다.
+ *
+ * blackTabBar: 관리자 유저 권한 설정페이지의 탭바 컬러입니다.
+ *
+ * blackTeamName: 연차, 당직 관리하기 페이지에 활용되는 팀명 BG컬러입니다.
+ *
+ * blackCompleteList: 연차, 당직 관리하기 페이지에 활용되는 "신청 중 목록","완료된 목록" BG컬러입니다.
+ *
+ * red: 메인색 외에 활용되는 폰트,버튼에 활용되는 레드컬러입니다.
+ *
+ * redSideMenu: 사이드 바에 활용되는 메뉴 하이라이트 컬러입니다.
+ *
+ * redTodayButton: 달력에 활용되는 Today버튼 BG컬러입니다.
+ *
+ * redContainer: 연차, 반차, 당직신청하기 페이지에 활용되는 컨테이너 BG컬러입니다.
+ *
+ * redConfirmButton: 연차, 반차, 당직신청하기 페이지에 활용되는 승인요청하기버튼 BG컬러입니다.
+ *
+ * redReject/blue: 연차, 당직  관리하기/내역보기 페이지에 활용되는 거절버튼 BG컬러, BorderLine입니다.
+ *
+ * redDisable/blueDisable: 연차, 당직  관리하기 페이지의 신청 내역에 활용되는 거절버튼 BG컬러, BorderLine입니다.
+ *
+ * grayAddTeam: 관리자 팀추가 페이지의 모달창에 사용되는 삭제버튼 BG컬러입니다.
+ *
+ * redDelete: 관리자 팀 추가 페이지의 모달창에 사용되는 추가버튼 BG컬러입니다.
+ *
+ * gray: 그레이가 활용되는 폰트, 버튼, disable 등에 활용되는 컬러입니다.
+ *
+ * grayFont: 관리자 유저 권한 설정페이지 탭바에 활용되는 폰트 컬러입니다.
+ *
+ * grayConfirmButton: 연차, 당직  관리하기 /  처리된 페이지 ,관리자 유저 권한 설정에 활용되는 확인버튼 BG컬러입니다.
+ *
+ */
+export const GlobalColors = {
+  mainColor: '#AA2727',
+
+  white: '#FFFFFF',
+
+  black: '#2D2D2D',
+  blackTabBar: '#383838',
+  blackTeamName: '#000000',
+  blackCompleteList: '#2C2C2C',
+
+  red: '#952A2A',
+  redSideMenu: '#F7CCCC',
+
+  redTodayButton: '#E15E5E',
+  redContainer: '#C94F4F',
+
+  redConfirmButton: '#6B1E1E',
+
+  redReject: '#D34747',
+  redDisable: '#E9A3A3',
+
+  redDelete: '#812E2E',
+
+  blue: '#476FD3',
+  blueDisable: '#A3B7E9',
+
+  gray: '#D9D9D9',
+  grayFont: '#A1A1A1',
+  grayConfirmButton: '#454545',
+  grayAddTeam: '#474747',
+}

--- a/src/styles/Theme.ts
+++ b/src/styles/Theme.ts
@@ -40,34 +40,36 @@
  * grayConfirmButton: 연차, 당직  관리하기 /  처리된 페이지 ,관리자 유저 권한 설정에 활용되는 확인버튼 BG컬러입니다.
  *
  */
-export const GlobalColors = {
-  mainColor: '#AA2727',
+export const theme = {
+  colors: {
+    mainColor: '#AA2727',
 
-  white: '#FFFFFF',
+    white: '#FFFFFF',
 
-  black: '#2D2D2D',
-  blackTabBar: '#383838',
-  blackTeamName: '#000000',
-  blackCompleteList: '#2C2C2C',
+    black: '#2D2D2D',
+    blackTabBar: '#383838',
+    blackTeamName: '#000000',
+    blackCompleteList: '#2C2C2C',
 
-  red: '#952A2A',
-  redSideMenu: '#F7CCCC',
+    red: '#952A2A',
+    redSideMenu: '#F7CCCC',
 
-  redTodayButton: '#E15E5E',
-  redContainer: '#C94F4F',
+    redTodayButton: '#E15E5E',
+    redContainer: '#C94F4F',
 
-  redConfirmButton: '#6B1E1E',
+    redConfirmButton: '#6B1E1E',
 
-  redReject: '#D34747',
-  redDisable: '#E9A3A3',
+    redReject: '#D34747',
+    redDisable: '#E9A3A3',
 
-  redDelete: '#812E2E',
+    redDelete: '#812E2E',
 
-  blue: '#476FD3',
-  blueDisable: '#A3B7E9',
+    blue: '#476FD3',
+    blueDisable: '#A3B7E9',
 
-  gray: '#D9D9D9',
-  grayFont: '#A1A1A1',
-  grayConfirmButton: '#454545',
-  grayAddTeam: '#474747',
+    gray: '#D9D9D9',
+    grayFont: '#A1A1A1',
+    grayConfirmButton: '#454545',
+    grayAddTeam: '#474747',
+  },
 }


### PR DESCRIPTION
[feat: Theme 사용을 위한 ThemeProvider활용](https://github.com/smash-teams/smash-teams-FE/pull/22/commits/734a0fbcdf96ec6b87496d8ff740051b6ce501dd) 
[734a0fb](https://github.com/smash-teams/smash-teams-FE/pull/22/commits/734a0fbcdf96ec6b87496d8ff740051b6ce501dd)
- 객체를 불러 활용하기 보단, 추후 추가 될 수도 있는 스타일의 글로벌
  적용을 위해 ThemeProvider를 활용 했습니다.

- 위와 같은 이유로 GlobalColor.ts는 삭제했습니다.

- 아래 예시처럼 활용해 주시면 됩니다.
export const SideBar = styled.div`
  background-color: ${({ theme }) => theme.colors.blue};