### PR TITLE
fix: 남은연차 카운팅, 연차/반차 표시버튼 스타일 수정

### DIFF
--- a/src/components/shiftFormContainer/index.tsx
+++ b/src/components/shiftFormContainer/index.tsx
@@ -24,6 +24,7 @@ export interface ShiftFormContainerProps {
 function ShiftFormContainer({ location, startDate, endDate, reason }: ShiftFormContainerProps) {
   const navigate = useNavigate()
   const [formType, setFormType] = useState<FormType>('DAYOFF')
+  // const [remainCount, setRemainCount] = useState<number>(20)
 
   const handleTitleChange = location === '/dayoff' ? (formType === 'DAYOFF' ? '연차' : '반차') : '당직'
   const handleStartTitleChange =
@@ -41,6 +42,11 @@ function ShiftFormContainer({ location, startDate, endDate, reason }: ShiftFormC
     setFormType('HALFOFF' as FormType)
   }
 
+  // const handleOffCounter =
+  //   formType === 'DAYOFF'
+  //     ? setRemainCount((remainCount) => remainCount - 1)
+  //     : setRemainCount((remainCount) => remainCount - 0.5)
+
   function formatDate(dateString: string | number): string {
     const date = new Date(dateString)
     const year = date.getFullYear()
@@ -51,7 +57,13 @@ function ShiftFormContainer({ location, startDate, endDate, reason }: ShiftFormC
   const formatStartDate = formatDate(startDate) as string
   const formatEndDate = formatDate(endDate) as string
 
-  const { data: myUser } = useQuery<LoginResponseData, AxiosError>('myUser', getUser)
+  const { data: myUser, isLoading: user } = useQuery<LoginResponseData, AxiosError>('myUser', getUser)
+  // useEffect(() => {
+  //   if (!user) {
+  //     setRemainCount(myUser?.data?.remain)
+  //   }
+  // }, [])
+
   const { mutate, isError, isLoading } = useMutation<ScheduleEnrollResponse, AxiosError, ScheduleEnroll>(
     () =>
       createUserSchedule({
@@ -117,8 +129,7 @@ function ShiftFormContainer({ location, startDate, endDate, reason }: ShiftFormC
         {location === '/dayoff' ? (
           <S.DayOffCountContainer>
             <p>남은 연차 날짜</p>
-            {/* <p>`Day-${'dayOffCount'}`</p> */}
-            <p>Day-17.5</p>
+            <p>{`Day-${myUser?.data?.remain}`}</p>
           </S.DayOffCountContainer>
         ) : null}
         <S.ShiftTitle>{handleTitleChange}</S.ShiftTitle>
@@ -185,10 +196,20 @@ function ShiftFormContainer({ location, startDate, endDate, reason }: ShiftFormC
         </S.InputWrapper>
         {location === '/dayoff' ? (
           <S.ButtonsWrapper>
-            <S.DayOffButton id="dayOff" type="submit" onClick={handleDayOffButtonClick}>
+            <S.DayOffButton
+              isClicked={handleTitleChange === '연차'}
+              id="dayOff"
+              type="submit"
+              onClick={handleDayOffButtonClick}
+            >
               연차
             </S.DayOffButton>
-            <S.HalfOffButton id="halfOff" type="submit" onClick={handleHalfOffButtonClick}>
+            <S.HalfOffButton
+              isClicked={handleTitleChange === '반차'}
+              id="halfOff"
+              type="submit"
+              onClick={handleHalfOffButtonClick}
+            >
               반차
             </S.HalfOffButton>
           </S.ButtonsWrapper>

--- a/src/components/shiftFormContainer/style.ts
+++ b/src/components/shiftFormContainer/style.ts
@@ -80,37 +80,27 @@ export const ButtonsWrapper = styled.div`
   margin: 82px 0 0 0;
   width: 100%;
 `
-export const DayOffButton = styled.button`
+export const DayOffButton = styled.button<{ isClicked: boolean }>`
   margin-right: 12px;
   padding: 16px 68px;
   width: 100%;
 
-  background-color: ${({ theme }) => theme.colors.white};
-  color: ${({ theme }) => theme.colors.mainColor};
+  background-color: ${({ theme, isClicked }) => (isClicked ? theme.colors.white : theme.colors.mainColor)};
+  color: ${({ theme, isClicked }) => (isClicked ? theme.colors.mainColor : theme.colors.white)};
   font-weight: 600;
   font-size: 16px;
   border-radius: 6px;
-
-  :hover {
-    background-color: ${({ theme }) => theme.colors.mainColor};
-    color: ${({ theme }) => theme.colors.white};
-  }
 `
-export const HalfOffButton = styled.button`
+export const HalfOffButton = styled.button<{ isClicked: boolean }>`
   margin-left: 12px;
   padding: 16px 68px;
   width: 100%;
 
-  background-color: ${({ theme }) => theme.colors.mainColor};
-  color: ${({ theme }) => theme.colors.white};
+  background-color: ${({ theme, isClicked }) => (isClicked ? theme.colors.white : theme.colors.mainColor)};
+  color: ${({ theme, isClicked }) => (isClicked ? theme.colors.mainColor : theme.colors.white)};
   font-weight: 600;
   font-size: 16px;
   border-radius: 6px;
-
-  :hover {
-    background-color: ${({ theme }) => theme.colors.white};
-    color: ${({ theme }) => theme.colors.mainColor};
-  }
 `
 
 export const SizedBox = styled.div`


### PR DESCRIPTION
- user의 remain(남은 연차일수)를 표시
- 연차, 반차 신청구분을 UI에 표시되게 하기 위한 styled-components props할당

---
#### 남은 연차 차감
남은 연차 차감은 관리자 페이지에서 승인을 해줘야 진행이 가능한 부분,

 - 남은 연차 갯수 또는 일수가 컨테이너에 출력 되어야 한다.
 - 연차/반차를 사용하면 남은 연차 차감이 -1 또는 -0.5 업데이팅 되어야 한다.